### PR TITLE
Remove redundant publish step for GitHub Packages in workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -41,10 +41,3 @@ jobs:
 
       - name: Test
         run: pnpm test
-
-      - name: Enable Auto-merge
-        if: success()
-        run: |
-          gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,11 +68,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish to GitHub Packages
-        run: pnpm publish --registry=https://npm.pkg.github.com
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Push version changes
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         run: git push --follow-tags
@@ -85,3 +80,5 @@ jobs:
           tag_name: v$(node -p "require('./package.json').version")
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
Eliminate the unnecessary publish step for GitHub Packages in the workflow to streamline the process.