### PR TITLE
fix: restore npm publishing via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,10 @@ jobs:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org/'
 
+      # npm >= 11.5.1 is required for trusted publishing (OIDC)
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
@@ -47,5 +51,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
## Summary
Switches npm publishing from the (now-invalid) `NPM_TOKEN` secret to **trusted publishing (OIDC)**. The last publish run failed with `EINVALIDNPMTOKEN` after npm's classic-token deprecation; with trusted publishing there is no token to store or rotate.

## Changes
- **`.github/workflows/publish.yml`**
  - Add an `npm install -g npm@latest` step — trusted publishing requires npm ≥ 11.5.1, while Node LTS bundles npm 10
  - Remove `NPM_TOKEN` from the release step's env (`id-token: write` permission was already present)
- **`.npmrc`** — remove the `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` line, which npm would treat as a fatal unresolved env reference once the variable is unset

## Prerequisites (done)
- Trusted publisher registered on npmjs.com for this repo + `publish.yml`
- `@semantic-release/npm` 13.1.5 (already in the lockfile) supports OIDC

## Merge note
Squash-merging with this PR's `fix:` title makes semantic-release cut **v0.1.7** on merge — publishing the response-format/timeout fix from #26/#27 and today's dependency updates via the new trusted-publishing flow. The repo's `NPM_TOKEN` Actions secret can be deleted afterward.

https://claude.ai/code/session_01TgRfrjQGwtnibunwDsxd9V

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgRfrjQGwtnibunwDsxd9V)_