### PR TITLE
Add resource mapper UI for OpenAPI operation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ Once you have filled out the spec URL, on operations you can click the dots and 
 ![image](https://github.com/user-attachments/assets/59dc9389-266a-4fb3-ab3a-90e3afb61b9a)
 
 
-This does not currently populate the parameters for the operation, so you will need to refer to the documentation of the endpoint you're using to know what parameters are required. This was just a quick handjam to get something working. I will be adding more features as I have time. Feel free to contribute!
+Once an operation is selected, the **Operation Parameters** section is populated directly from the OpenAPI spec — no need to refer to the API documentation. Required parameters (path, query, header, and cookie) are shown automatically with their expected types, optional parameters can be added from a dropdown, and enums are presented as selectable options. Top-level request body properties from the spec are exposed as individual `(body)` fields and are merged into the JSON request body.
+
+If you need to send something the spec doesn't define (or the spec is incomplete), the **Custom Parameters** collection still lets you add arbitrary path, query, header, and cookie parameters manually, and the **Request Body** field accepts raw JSON. Spec-defined and custom parameters are sent together.
+
+I will be adding more features as I have time. Feel free to contribute!
 
 ## Resources
 

--- a/nodes/OpenAPINode/OpenApiDescription.ts
+++ b/nodes/OpenAPINode/OpenApiDescription.ts
@@ -24,7 +24,37 @@ export const openApiOperations: INodeProperties[] = [
 // Define fields for the OpenAPI node
 export const openApiFields: INodeProperties[] = [
 	{
-		displayName: 'Parameters',
+		displayName: 'Operation Parameters',
+		name: 'operationParameters',
+		type: 'resourceMapper',
+		noDataExpression: true,
+		default: {
+			mappingMode: 'defineBelow',
+			value: null,
+		},
+		displayOptions: {
+			show: {
+				resource: ['apiEndpoint'],
+			},
+		},
+		typeOptions: {
+			loadOptionsDependsOn: ['openApiUrl', 'operation'],
+			resourceMapper: {
+				resourceMapperMethod: 'getOperationParameters',
+				mode: 'add',
+				fieldWords: {
+					singular: 'parameter',
+					plural: 'parameters',
+				},
+				addAllFields: false,
+				supportAutoMap: false,
+				noFieldsError: 'The selected operation does not define any parameters in the OpenAPI spec. Use the Custom Parameters field below if you still need to send values.',
+			},
+		},
+		description: 'Parameters defined in the OpenAPI spec for the selected operation. Required parameters are added automatically; optional ones can be added as needed.',
+	},
+	{
+		displayName: 'Custom Parameters',
 		name: 'parameters',
 		placeholder: 'Add Parameter',
 		type: 'fixedCollection',
@@ -84,7 +114,7 @@ export const openApiFields: INodeProperties[] = [
 				],
 			},
 		],
-		description: 'Parameters to be sent',
+		description: 'Manually defined parameters, sent in addition to the spec-defined operation parameters above',
 	},
 	{
 		displayName: 'Request Body',

--- a/nodes/OpenAPINode/OpenApiHelper.ts
+++ b/nodes/OpenAPINode/OpenApiHelper.ts
@@ -1,4 +1,4 @@
-import { IDataObject } from 'n8n-workflow';
+import { IDataObject, FieldType, INodePropertyOptions } from 'n8n-workflow';
 import * as yaml from 'yaml';
 
 // Function to load and parse OpenAPI specification
@@ -46,6 +46,167 @@ export async function loadOpenApiSpec(url: string): Promise<any> {
 	} catch (error) {
 		throw new Error(`Failed to parse response: ${error.message}. Make sure the URL returns valid JSON or YAML.`);
 	}
+}
+
+// Resolve internal $ref pointers (e.g. '#/components/parameters/Limit') within the spec.
+// External references are returned unchanged.
+export function resolveRef(spec: any, obj: any): any {
+	let current = obj;
+	const seen = new Set<string>();
+
+	while (current && typeof current === 'object' && typeof current.$ref === 'string') {
+		const ref = current.$ref as string;
+		if (!ref.startsWith('#/') || seen.has(ref)) {
+			return current;
+		}
+		seen.add(ref);
+
+		let resolved: any = spec;
+		for (const segment of ref.slice(2).split('/')) {
+			// JSON pointer escaping: ~1 = '/', ~0 = '~'
+			resolved = resolved?.[segment.replace(/~1/g, '/').replace(/~0/g, '~')];
+		}
+
+		if (resolved === undefined) {
+			return current;
+		}
+		current = resolved;
+	}
+
+	return current;
+}
+
+export interface IOperationParameter {
+	name: string;
+	in: 'query' | 'path' | 'header' | 'cookie';
+	required: boolean;
+	description?: string;
+	schema?: any;
+}
+
+export interface IOperationDetails {
+	parameters: IOperationParameter[];
+	requestBodySchema?: any;
+	requestBodyRequired: boolean;
+}
+
+// Extract the parameters and request body schema defined in the spec for a single operation.
+// Supports both OpenAPI 3.x (requestBody) and Swagger 2.0 (in: 'body' parameters).
+export function getOperationDetails(spec: any, method: string, path: string): IOperationDetails {
+	const details: IOperationDetails = { parameters: [], requestBodyRequired: false };
+
+	const pathItem = resolveRef(spec, spec?.paths?.[path]);
+	const operation = pathItem?.[method.toLowerCase()];
+	if (!operation || typeof operation !== 'object') {
+		return details;
+	}
+
+	// Operation-level parameters override path-level ones with the same name and location
+	const merged = new Map<string, IOperationParameter>();
+	const rawParameters = [
+		...(Array.isArray(pathItem.parameters) ? pathItem.parameters : []),
+		...(Array.isArray(operation.parameters) ? operation.parameters : []),
+	];
+
+	for (const rawParam of rawParameters) {
+		const param = resolveRef(spec, rawParam);
+		if (!param?.name || !param?.in) continue;
+
+		if (param.in === 'body') {
+			// Swagger 2.0 style request body
+			details.requestBodySchema = resolveRef(spec, param.schema);
+			details.requestBodyRequired = param.required === true;
+			continue;
+		}
+
+		if (!['query', 'path', 'header', 'cookie'].includes(param.in)) continue;
+
+		merged.set(`${param.in}:${param.name}`, {
+			name: param.name,
+			in: param.in,
+			required: param.in === 'path' ? true : param.required === true,
+			description: param.description,
+			// Swagger 2.0 puts type/enum directly on the parameter instead of under schema
+			schema: resolveRef(spec, param.schema ?? (param.type ? param : undefined)),
+		});
+	}
+	details.parameters = [...merged.values()];
+
+	// OpenAPI 3.x request body (first JSON-like content type)
+	const requestBody = resolveRef(spec, operation.requestBody);
+	if (requestBody?.content) {
+		const jsonContentKey = Object.keys(requestBody.content).find((key) => key.includes('json'));
+		if (jsonContentKey) {
+			details.requestBodySchema = resolveRef(spec, requestBody.content[jsonContentKey].schema);
+			details.requestBodyRequired = requestBody.required === true;
+		}
+	}
+
+	return details;
+}
+
+// Map an OpenAPI/JSON schema to the field type used by n8n's resource mapper UI
+export function mapSchemaToFieldType(schema: any): { type: FieldType; options?: INodePropertyOptions[] } {
+	if (!schema || typeof schema !== 'object') {
+		return { type: 'string' };
+	}
+
+	if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+		return {
+			type: 'options',
+			options: schema.enum.map((value: unknown) => ({ name: String(value), value: value as string })),
+		};
+	}
+
+	switch (schema.type) {
+		case 'integer':
+		case 'number':
+			return { type: 'number' };
+		case 'boolean':
+			return { type: 'boolean' };
+		case 'array':
+			return { type: 'array' };
+		case 'object':
+			return { type: 'object' };
+		case 'string':
+			return { type: schema.format === 'date-time' ? 'dateTime' : 'string' };
+		default:
+			return { type: 'string' };
+	}
+}
+
+export interface ISplitMappedParameters {
+	parameters: IDataObject[];
+	bodyFields: IDataObject;
+}
+
+// Split resource mapper values (keyed as '<location>:<name>') into request parameters
+// (compatible with the manual parameters collection) and request body fields
+export function splitMappedParameters(mapped: IDataObject): ISplitMappedParameters {
+	const parameters: IDataObject[] = [];
+	const bodyFields: IDataObject = {};
+
+	for (const [id, value] of Object.entries(mapped)) {
+		if (value === undefined || value === null || value === '') continue;
+
+		const separatorIndex = id.indexOf(':');
+		if (separatorIndex === -1) continue;
+
+		const location = id.slice(0, separatorIndex);
+		const name = id.slice(separatorIndex + 1);
+
+		if (location === 'body') {
+			bodyFields[name] = value;
+		} else if (['query', 'path', 'header', 'cookie'].includes(location)) {
+			parameters.push({
+				name,
+				value: typeof value === 'object' ? JSON.stringify(value) : String(value),
+				type: location,
+			});
+		}
+	}
+
+	return { parameters, bodyFields };
 }
 
 // Helper function to join URL parts correctly

--- a/nodes/OpenAPINode/OpenApiNode.node.ts
+++ b/nodes/OpenAPINode/OpenApiNode.node.ts
@@ -8,11 +8,35 @@ import {
 	INodePropertyOptions,
 	ICredentialDataDecryptedObject,
 	INodeInputConfiguration,
-	INodeOutputConfiguration
+	INodeOutputConfiguration,
+	ResourceMapperFields,
+	ResourceMapperField
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import { openApiOperations, openApiFields } from './OpenApiDescription';
-import { loadOpenApiSpec, executeOpenApiRequest, IBinaryResponse } from './OpenApiHelper';
+import {
+	loadOpenApiSpec,
+	executeOpenApiRequest,
+	getOperationDetails,
+	mapSchemaToFieldType,
+	splitMappedParameters,
+	resolveRef,
+	IBinaryResponse
+} from './OpenApiHelper';
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'];
+
+// The operation parameter is stored as 'method:path' but may also arrive as an object via expressions
+function parseOperationValue(operation: unknown): { method: string; path: string } | null {
+	if (typeof operation === 'string' && operation.includes(':')) {
+		const separatorIndex = operation.indexOf(':');
+		return { method: operation.slice(0, separatorIndex), path: operation.slice(separatorIndex + 1) };
+	}
+	if (typeof operation === 'object' && operation !== null && 'method' in operation && 'path' in operation) {
+		return operation as { method: string; path: string };
+	}
+	return null;
+}
 
 export class OpenApiNode implements INodeType {
 	description: INodeTypeDescription = {
@@ -81,6 +105,8 @@ export class OpenApiNode implements INodeType {
 					// Parse paths and methods from the OpenAPI spec
 					for (const path in spec.paths) {
 						for (const method in spec.paths[path]) {
+							// Skip non-operation keys like path-level 'parameters' or 'servers'
+							if (!HTTP_METHODS.includes(method.toLowerCase())) continue;
 							const operation = spec.paths[path][method];
 							operations.push({
 								name: `${method.toUpperCase()} ${path} - ${operation.summary || operation.operationId || ''}`,
@@ -93,6 +119,67 @@ export class OpenApiNode implements INodeType {
 				} catch (error) {
 					throw new NodeOperationError(this.getNode(), `Failed to load OpenAPI spec: ${error.message}`);
 				}
+			},
+		},
+		resourceMapping: {
+			// Build the parameter fields for the selected operation from the OpenAPI spec
+			async getOperationParameters(this: ILoadOptionsFunctions): Promise<ResourceMapperFields> {
+				const openApiUrl = this.getNodeParameter('openApiUrl', 0) as string;
+				const operation = parseOperationValue(this.getNodeParameter('operation', 0));
+
+				if (!openApiUrl || !operation) {
+					return { fields: [] };
+				}
+
+				let spec: any;
+				try {
+					spec = await loadOpenApiSpec(openApiUrl);
+				} catch (error) {
+					throw new NodeOperationError(this.getNode(), `Failed to load OpenAPI spec: ${error.message}`);
+				}
+
+				const { parameters, requestBodySchema, requestBodyRequired } = getOperationDetails(
+					spec,
+					operation.method,
+					operation.path,
+				);
+
+				const fields: ResourceMapperField[] = parameters.map((param) => {
+					const { type, options } = mapSchemaToFieldType(param.schema);
+					return {
+						id: `${param.in}:${param.name}`,
+						displayName: `${param.name} (${param.in})`,
+						required: param.required,
+						defaultMatch: false,
+						canBeUsedToMatch: false,
+						display: true,
+						type,
+						options,
+					};
+				});
+
+				// Expose top-level request body properties as individual fields
+				if (requestBodySchema?.properties && typeof requestBodySchema.properties === 'object') {
+					const requiredProps = new Set(
+						Array.isArray(requestBodySchema.required) ? requestBodySchema.required : [],
+					);
+					for (const [propName, rawPropSchema] of Object.entries(requestBodySchema.properties)) {
+						const propSchema = resolveRef(spec, rawPropSchema);
+						const { type, options } = mapSchemaToFieldType(propSchema);
+						fields.push({
+							id: `body:${propName}`,
+							displayName: `${propName} (body)`,
+							required: requestBodyRequired && requiredProps.has(propName),
+							defaultMatch: false,
+							canBeUsedToMatch: false,
+							display: true,
+							type,
+							options,
+						});
+					}
+				}
+
+				return { fields };
 			},
 		},
 	};
@@ -121,20 +208,26 @@ export class OpenApiNode implements INodeType {
 		for (let i = 0; i < items.length; i++) {
 			try {
 				// Get operation details
-				const operation = this.getNodeParameter('operation', i) as string | { method: string; path: string }; // updated type to support both string and object formats
-
-				// Updated extraction of method and path from the operation parameter:
-				let method: string, path: string;
-				if (typeof operation === 'string') {
-					[method, path] = operation.split(':');
-				} else if (typeof operation === 'object' && operation !== null) {
-					({ method, path } = operation);
-				} else {
+				const parsedOperation = parseOperationValue(this.getNodeParameter('operation', i));
+				if (!parsedOperation) {
 					throw new NodeOperationError(this.getNode(), 'Invalid operation parameter format');
 				}
+				const { method, path } = parsedOperation;
 
 				// Get parameters and request body
-				const parameters = this.getNodeParameter('parameters', i, {}) as IDataObject;
+				let parameters = this.getNodeParameter('parameters', i, {}) as IDataObject;
+
+				// Spec-defined parameters configured through the resource mapper UI
+				const mappedValues = this.getNodeParameter('operationParameters.value', i, null) as IDataObject | null;
+				const { parameters: specParameters, bodyFields } = splitMappedParameters(mappedValues ?? {});
+
+				if (specParameters.length > 0) {
+					const manualParameters = Array.isArray(parameters.parameter)
+						? (parameters.parameter as IDataObject[])
+						: [];
+					// Manual parameters come last so header values can override spec-mapped ones
+					parameters = { ...parameters, parameter: [...specParameters, ...manualParameters] };
+				}
 
 				// Make request body truly optional
 				let requestBody: IDataObject = {};
@@ -155,6 +248,11 @@ export class OpenApiNode implements INodeType {
 					}
 				} else {
 					requestBody = rawRequestBody as IDataObject;
+				}
+
+				// Spec-mapped body fields take precedence over the raw JSON body
+				if (Object.keys(bodyFields).length > 0) {
+					requestBody = { ...requestBody, ...bodyFields };
 				}
 
 				// Get request options (response format, timeout)

--- a/tests/OpenApiDescription.test.ts
+++ b/tests/OpenApiDescription.test.ts
@@ -32,6 +32,19 @@ describe('OpenApiDescription', () => {
 			});
 		});
 
+		it('should include an Operation Parameters resource mapper driven by the spec', () => {
+			const operationParametersField = openApiFields.find((field) => field.name === 'operationParameters');
+			expect(operationParametersField).toBeDefined();
+			if (operationParametersField) {
+				expect(operationParametersField.type).toBe('resourceMapper');
+				expect(operationParametersField.default).toEqual({ mappingMode: 'defineBelow', value: null });
+				const typeOptions = operationParametersField.typeOptions;
+				expect(typeOptions?.loadOptionsDependsOn).toEqual(['openApiUrl', 'operation']);
+				expect(typeOptions?.resourceMapper?.resourceMapperMethod).toBe('getOperationParameters');
+				expect(typeOptions?.resourceMapper?.mode).toBe('add');
+			}
+		});
+
 		it('should include a Parameters field of fixedCollection type', () => {
 			const parametersField = openApiFields.find((field) => field.name === 'parameters');
 			expect(parametersField).toBeDefined();

--- a/tests/OpenApiHelper.test.ts
+++ b/tests/OpenApiHelper.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadOpenApiSpec, executeOpenApiRequest } from '../nodes/OpenAPINode/OpenApiHelper';
+import {
+	loadOpenApiSpec,
+	executeOpenApiRequest,
+	resolveRef,
+	getOperationDetails,
+	mapSchemaToFieldType,
+	splitMappedParameters,
+} from '../nodes/OpenAPINode/OpenApiHelper';
 import { IDataObject } from 'n8n-workflow';
 
 // Mock global fetch
@@ -76,6 +83,222 @@ describe('OpenApiHelper', () => {
 			});
 
 			await expect(loadOpenApiSpec('https://example.com/invalid')).rejects.toThrow('Failed to parse response');
+		});
+	});
+
+	describe('resolveRef', () => {
+		const spec = {
+			components: {
+				parameters: {
+					Limit: { name: 'limit', in: 'query', schema: { type: 'integer' } },
+				},
+				schemas: {
+					User: { type: 'object', properties: { name: { type: 'string' } } },
+					// Reference chain: Alias -> User
+					Alias: { $ref: '#/components/schemas/User' },
+					// Circular reference
+					Loop: { $ref: '#/components/schemas/Loop' },
+				},
+			},
+		};
+
+		it('should resolve internal references', () => {
+			const resolved = resolveRef(spec, { $ref: '#/components/parameters/Limit' });
+			expect(resolved).toEqual({ name: 'limit', in: 'query', schema: { type: 'integer' } });
+		});
+
+		it('should resolve chained references', () => {
+			const resolved = resolveRef(spec, { $ref: '#/components/schemas/Alias' });
+			expect(resolved).toEqual(spec.components.schemas.User);
+		});
+
+		it('should return non-reference objects unchanged', () => {
+			const obj = { type: 'string' };
+			expect(resolveRef(spec, obj)).toBe(obj);
+		});
+
+		it('should not loop forever on circular references', () => {
+			const resolved = resolveRef(spec, { $ref: '#/components/schemas/Loop' });
+			expect(resolved).toEqual({ $ref: '#/components/schemas/Loop' });
+		});
+
+		it('should return unresolvable references unchanged', () => {
+			const ref = { $ref: '#/components/schemas/Missing' };
+			expect(resolveRef(spec, ref)).toBe(ref);
+		});
+	});
+
+	describe('getOperationDetails', () => {
+		it('should extract operation parameters from an OpenAPI 3 spec', () => {
+			const spec = {
+				paths: {
+					'/users/{userId}': {
+						parameters: [
+							{ name: 'userId', in: 'path', required: true, schema: { type: 'integer' } },
+						],
+						get: {
+							parameters: [
+								{ name: 'verbose', in: 'query', schema: { type: 'boolean' } },
+								{ $ref: '#/components/parameters/Limit' },
+							],
+						},
+					},
+				},
+				components: {
+					parameters: {
+						Limit: { name: 'limit', in: 'query', schema: { type: 'integer' } },
+					},
+				},
+			};
+
+			const details = getOperationDetails(spec, 'GET', '/users/{userId}');
+
+			expect(details.parameters).toEqual([
+				{ name: 'userId', in: 'path', required: true, description: undefined, schema: { type: 'integer' } },
+				{ name: 'verbose', in: 'query', required: false, description: undefined, schema: { type: 'boolean' } },
+				{ name: 'limit', in: 'query', required: false, description: undefined, schema: { type: 'integer' } },
+			]);
+			expect(details.requestBodySchema).toBeUndefined();
+		});
+
+		it('should let operation-level parameters override path-level ones', () => {
+			const spec = {
+				paths: {
+					'/items': {
+						parameters: [{ name: 'limit', in: 'query', schema: { type: 'string' } }],
+						get: {
+							parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+						},
+					},
+				},
+			};
+
+			const details = getOperationDetails(spec, 'get', '/items');
+			expect(details.parameters).toHaveLength(1);
+			expect(details.parameters[0].required).toBe(true);
+			expect(details.parameters[0].schema).toEqual({ type: 'integer' });
+		});
+
+		it('should extract the JSON request body schema from an OpenAPI 3 spec', () => {
+			const spec = {
+				paths: {
+					'/users': {
+						post: {
+							requestBody: {
+								required: true,
+								content: {
+									'application/json': {
+										schema: { $ref: '#/components/schemas/User' },
+									},
+								},
+							},
+						},
+					},
+				},
+				components: {
+					schemas: {
+						User: {
+							type: 'object',
+							required: ['name'],
+							properties: { name: { type: 'string' }, age: { type: 'integer' } },
+						},
+					},
+				},
+			};
+
+			const details = getOperationDetails(spec, 'post', '/users');
+			expect(details.requestBodyRequired).toBe(true);
+			expect(details.requestBodySchema).toEqual(spec.components.schemas.User);
+		});
+
+		it('should extract body and parameter types from a Swagger 2.0 spec', () => {
+			const spec = {
+				swagger: '2.0',
+				paths: {
+					'/pets': {
+						post: {
+							parameters: [
+								{ name: 'status', in: 'query', type: 'string', enum: ['available', 'sold'] },
+								{
+									name: 'body',
+									in: 'body',
+									required: true,
+									schema: { type: 'object', properties: { name: { type: 'string' } } },
+								},
+							],
+						},
+					},
+				},
+			};
+
+			const details = getOperationDetails(spec, 'POST', '/pets');
+			expect(details.parameters).toHaveLength(1);
+			expect(details.parameters[0].name).toBe('status');
+			expect(details.parameters[0].schema.enum).toEqual(['available', 'sold']);
+			expect(details.requestBodyRequired).toBe(true);
+			expect(details.requestBodySchema).toEqual({ type: 'object', properties: { name: { type: 'string' } } });
+		});
+
+		it('should return empty details for unknown operations', () => {
+			expect(getOperationDetails({ paths: {} }, 'get', '/missing')).toEqual({
+				parameters: [],
+				requestBodyRequired: false,
+			});
+		});
+	});
+
+	describe('mapSchemaToFieldType', () => {
+		it('should map basic schema types', () => {
+			expect(mapSchemaToFieldType({ type: 'integer' }).type).toBe('number');
+			expect(mapSchemaToFieldType({ type: 'number' }).type).toBe('number');
+			expect(mapSchemaToFieldType({ type: 'boolean' }).type).toBe('boolean');
+			expect(mapSchemaToFieldType({ type: 'array' }).type).toBe('array');
+			expect(mapSchemaToFieldType({ type: 'object' }).type).toBe('object');
+			expect(mapSchemaToFieldType({ type: 'string' }).type).toBe('string');
+			expect(mapSchemaToFieldType({ type: 'string', format: 'date-time' }).type).toBe('dateTime');
+			expect(mapSchemaToFieldType(undefined).type).toBe('string');
+		});
+
+		it('should map enums to options', () => {
+			const result = mapSchemaToFieldType({ type: 'string', enum: ['asc', 'desc'] });
+			expect(result.type).toBe('options');
+			expect(result.options).toEqual([
+				{ name: 'asc', value: 'asc' },
+				{ name: 'desc', value: 'desc' },
+			]);
+		});
+	});
+
+	describe('splitMappedParameters', () => {
+		it('should split mapped values into parameters and body fields', () => {
+			const result = splitMappedParameters({
+				'path:userId': 123,
+				'query:verbose': true,
+				'header:X-Trace': 'abc',
+				'cookie:session': 'xyz',
+				'body:name': 'Test User',
+				'body:tags': ['a', 'b'],
+			});
+
+			expect(result.parameters).toEqual([
+				{ name: 'userId', value: '123', type: 'path' },
+				{ name: 'verbose', value: 'true', type: 'query' },
+				{ name: 'X-Trace', value: 'abc', type: 'header' },
+				{ name: 'session', value: 'xyz', type: 'cookie' },
+			]);
+			expect(result.bodyFields).toEqual({ name: 'Test User', tags: ['a', 'b'] });
+		});
+
+		it('should skip empty values and unknown keys', () => {
+			const result = splitMappedParameters({
+				'query:empty': '',
+				'query:missing': null,
+				noSeparator: 'value',
+				'unknown:location': 'value',
+			} as IDataObject);
+
+			expect(result.parameters).toEqual([]);
+			expect(result.bodyFields).toEqual({});
 		});
 	});
 

--- a/tests/OpenApiNode.node.test.ts
+++ b/tests/OpenApiNode.node.test.ts
@@ -21,11 +21,15 @@ vi.mock('../nodes/OpenAPINode/OpenApiDescription', () => ({
 	openApiFields: [],
 }));
 
-// Mock the helpers used by the node
-vi.mock('../nodes/OpenAPINode/OpenApiHelper', () => ({
-  loadOpenApiSpec: vi.fn(),
-  executeOpenApiRequest: vi.fn(),
-}));
+// Mock the network-bound helpers used by the node, keep the pure helpers real
+vi.mock('../nodes/OpenAPINode/OpenApiHelper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../nodes/OpenAPINode/OpenApiHelper')>();
+  return {
+    ...actual,
+    loadOpenApiSpec: vi.fn(),
+    executeOpenApiRequest: vi.fn(),
+  };
+});
 
 describe('OpenApiNode', () => {
   let node: OpenApiNode;
@@ -76,6 +80,100 @@ describe('OpenApiNode', () => {
       // Act & Assert
       await expect(
         node.methods.loadOptions!.loadOperations.call(loadOptionsMethods)
+      ).rejects.toThrow(NodeOperationError);
+    });
+  });
+
+  describe('resourceMapping.getOperationParameters', () => {
+    const specWithParams = {
+      paths: {
+        '/users/{userId}': {
+          get: {
+            parameters: [
+              { name: 'userId', in: 'path', required: true, schema: { type: 'integer' } },
+              { name: 'verbose', in: 'query', schema: { type: 'boolean' } },
+            ],
+          },
+          put: {
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['name'],
+                    properties: { name: { type: 'string' }, age: { type: 'integer' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it('should build resource mapper fields from spec parameters', async () => {
+      (loadOpenApiSpec as any).mockResolvedValue(specWithParams);
+      loadOptionsMethods.getNodeParameter = vi.fn((param: string) => {
+        if (param === 'openApiUrl') return 'https://example.com/spec';
+        if (param === 'operation') return 'get:/users/{userId}';
+        return undefined;
+      }) as any;
+
+      const result = await node.methods.resourceMapping!.getOperationParameters.call(loadOptionsMethods);
+
+      expect(result.fields).toHaveLength(2);
+      expect(result.fields[0]).toMatchObject({
+        id: 'path:userId',
+        displayName: 'userId (path)',
+        required: true,
+        type: 'number',
+      });
+      expect(result.fields[1]).toMatchObject({
+        id: 'query:verbose',
+        required: false,
+        type: 'boolean',
+      });
+    });
+
+    it('should expose request body properties as body fields', async () => {
+      (loadOpenApiSpec as any).mockResolvedValue(specWithParams);
+      loadOptionsMethods.getNodeParameter = vi.fn((param: string) => {
+        if (param === 'openApiUrl') return 'https://example.com/spec';
+        if (param === 'operation') return 'put:/users/{userId}';
+        return undefined;
+      }) as any;
+
+      const result = await node.methods.resourceMapping!.getOperationParameters.call(loadOptionsMethods);
+
+      expect(result.fields).toEqual([
+        expect.objectContaining({ id: 'body:name', required: true, type: 'string' }),
+        expect.objectContaining({ id: 'body:age', required: false, type: 'number' }),
+      ]);
+    });
+
+    it('should return no fields when no operation is selected', async () => {
+      loadOptionsMethods.getNodeParameter = vi.fn((param: string) => {
+        if (param === 'openApiUrl') return 'https://example.com/spec';
+        if (param === 'operation') return '';
+        return undefined;
+      }) as any;
+
+      const result = await node.methods.resourceMapping!.getOperationParameters.call(loadOptionsMethods);
+      expect(result.fields).toEqual([]);
+      expect(loadOpenApiSpec).not.toHaveBeenCalled();
+    });
+
+    it('should throw NodeOperationError when spec loading fails', async () => {
+      (loadOpenApiSpec as any).mockRejectedValue(new Error('Spec load error'));
+      loadOptionsMethods.getNodeParameter = vi.fn((param: string) => {
+        if (param === 'openApiUrl') return 'https://example.com/spec';
+        if (param === 'operation') return 'get:/users/{userId}';
+        return undefined;
+      }) as any;
+
+      await expect(
+        node.methods.resourceMapping!.getOperationParameters.call(loadOptionsMethods)
       ).rejects.toThrow(NodeOperationError);
     });
   });
@@ -190,6 +288,43 @@ describe('OpenApiNode', () => {
         data: { data: 'base64-data', mimeType: 'application/pdf' },
       });
       expect(result[0][0].json).toEqual({});
+    });
+
+    it('should merge resource mapper values into parameters and request body', async () => {
+      executeFunctions.getNodeParameter = vi.fn((param: string, index: number, defaultValue?: unknown) => {
+        if (param === 'openApiUrl') return 'https://example.com/spec';
+        if (param === 'baseApiUrl') return 'https://api.example.com';
+        if (param === 'operation') return 'post:/users/{userId}';
+        if (param === 'parameters') return { parameter: [{ name: 'X-Manual', value: 'manual', type: 'header' }] };
+        if (param === 'operationParameters.value') {
+          return {
+            'path:userId': 42,
+            'query:verbose': true,
+            'body:name': 'Test User',
+          };
+        }
+        if (param === 'requestBody') return '{"existing": "value"}';
+        return defaultValue;
+      }) as any;
+
+      await node.execute.call(executeFunctions);
+
+      expect(executeOpenApiRequest).toHaveBeenCalledWith(
+        fakeSpec,
+        'post',
+        '/users/{userId}',
+        {
+          parameter: [
+            { name: 'userId', value: '42', type: 'path' },
+            { name: 'verbose', value: 'true', type: 'query' },
+            { name: 'X-Manual', value: 'manual', type: 'header' },
+          ],
+        },
+        { existing: 'value', name: 'Test User' },
+        { auth: 'dummy' },
+        'https://api.example.com',
+        { responseFormat: 'json', timeout: undefined }
+      );
     });
 
     it('should add error to return items and continue when continueOnFail is true', async () => {


### PR DESCRIPTION
## Summary
This PR adds a resource mapper UI component to the OpenAPI node that automatically exposes operation parameters and request body fields defined in the OpenAPI specification. Users can now visually map and configure parameters without manually referencing API documentation.

## Key Changes

### Core Helper Functions (OpenApiHelper.ts)
- **`resolveRef()`**: Resolves JSON pointer references (`$ref`) within OpenAPI specs, with circular reference detection
- **`getOperationDetails()`**: Extracts parameters and request body schema for a specific operation, supporting both OpenAPI 3.x and Swagger 2.0 formats
- **`mapSchemaToFieldType()`**: Maps OpenAPI/JSON schema types to n8n field types, including enum-to-options conversion
- **`splitMappedParameters()`**: Splits resource mapper values (keyed as `<location>:<name>`) into request parameters and body fields

### Node Implementation (OpenApiNode.node.ts)
- Added `resourceMapping.getOperationParameters()` method that dynamically builds parameter fields from the loaded OpenAPI spec
- Added `parseOperationValue()` helper to handle operation parameter as both string (`"method:path"`) and object formats
- Updated `execute()` to merge resource mapper values with manual parameters, with proper precedence handling
- Fixed operation path iteration to skip non-HTTP-method keys (e.g., `parameters`, `servers`)

### UI Configuration (OpenApiDescription.ts)
- Added new "Operation Parameters" resource mapper field that loads options based on selected operation
- Renamed "Parameters" to "Custom Parameters" to clarify the distinction
- Updated field descriptions to explain the relationship between spec-defined and custom parameters

### Test Coverage
- Comprehensive tests for all new helper functions covering edge cases (circular refs, missing refs, chained refs)
- Tests for `getOperationDetails()` with both OpenAPI 3.x and Swagger 2.0 specs
- Tests for resource mapper integration in the node's execute method
- Updated mocking strategy to preserve pure helper functions while mocking network-bound ones

## Implementation Details
- Operation-level parameters override path-level parameters with the same name and location
- Request body properties are exposed as individual `body:*` fields in the resource mapper
- Manual parameters are appended after spec-mapped parameters, allowing header overrides
- Spec-mapped body fields take precedence over raw JSON body input
- Proper error handling with `NodeOperationError` when spec loading fails

https://claude.ai/code/session_01Lgn5imAcSVg1NyR9ihGrAb