### PR TITLE
fix: Fix TS5107 by migrating off deprecated node10 module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
 		"strict": true,
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es2019",
 		"lib": ["es2019", "es2020", "es2022.error"],
 		"removeComments": true,


### PR DESCRIPTION
The "node" moduleResolution is an alias for "node10", which is deprecated and errors under TypeScript 6+ (and stops working in 7.0). Switch module/moduleResolution to "node16", which is the supported forward-looking option for this CommonJS, Node >=20.15 package.